### PR TITLE
Фикс 4pda

### DIFF
--- a/direct-links-out.user.js
+++ b/direct-links-out.user.js
@@ -239,8 +239,10 @@
         }
         else if (/soundcloud/i.test(loc))
             anchor = "exit.sc/?url=";
-        else if (/4pda/i.test(loc))
+        else if (/4pda/i.test(loc)){
             anchor = 'go/?u=';
+            after = '&e=';
+        }
         else if (/reactor/i.test(loc))
             anchor = 'url=';
         else if (/mozilla/i.test(loc))


### PR DESCRIPTION
Ссылки на сторонние ресурсы с недавних пор стали портить ещё больше, как пример: в посту http://4pda.ru/forum/index.php?showtopic=699990&view=findpost&p=48328309 ссылка ведёт не на https://cloud.mail.ru/public/C1N3cH5gLFw8/Dead%20Effect%202%20151215.0254%20%7BRus%7D%20%20Root%20MOD%20.apk , а на http://4pda.ru/pages/go/?u=https://cloud.mail.ru/public/C1N3cH5gLFw8/Dead%20Effect%202%20151215.0254%20%7BRus%7D%20%20Root%20MOD%20.apk&e=48328309 . Без фикса обрезывается лишь начало ссылки, т.е. остаётся https://cloud.mail.ru/public/C1N3cH5gLFw8/Dead%20Effect%202%20151215.0254%20%7BRus%7D%20%20Root%20MOD%20.apk&e=48328309 , после чего ссылка становится нерабочей.